### PR TITLE
Revise default Spark and Yarn configs based on instance info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,12 +24,13 @@ wheels/
 *.egg
 pip-wheel-metadata/
 .venv/
+*.DS_Store
 
 # Compiling / running local tests
-test/resources/code/scala/hello-scala-spark/lib_managed/
-test/resources/code/scala/hello-scala-spark/project/
-test/resources/code/scala/hello-scala-spark/target/
-test/resources/code/java/hello-java-spark/target/
+test/resources/code/scala/*/lib_managed/
+test/resources/code/scala/*/project/
+test/resources/code/scala/*/target/
+test/resources/code/java/*/target/
 test/resources/data/output/*
 
 .vim
@@ -44,6 +45,8 @@ container/*.whl
 .idea/*
 *.iml
 
+aws-config/
+
 # Don't commit emr spark packages
 *.tar
 *.tar.gz
@@ -53,4 +56,3 @@ container/*.whl
 
 # FIXME: remove this once we're consuming EMR packages through build
 emr-spark-packages
-

--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,12 @@ install-container-library:
 	pip install --upgrade dist/smspark-0.1-py3-none-any.whl
 	safety check  # https://github.com/pyupio/safety
 
+build-static-config:
+	./scripts/fetch-ec2-instance-type-info.sh --region ${REGION} --use-case ${USE_CASE} --spark-version ${SPARK_VERSION} \
+	--processor ${PROCESSOR} --framework-version ${FRAMEWORK_VERSION} --sm-version ${SM_VERSION}
+
 # Builds docker image.
-build: download-emr-packages build-container-library
+build: download-emr-packages build-container-library build-static-config
 	./scripts/build.sh --region ${REGION} --use-case ${USE_CASE} --spark-version ${SPARK_VERSION} \
 	--processor ${PROCESSOR} --framework-version ${FRAMEWORK_VERSION} --sm-version ${SM_VERSION}
 

--- a/scripts/fetch-ec2-instance-type-info.sh
+++ b/scripts/fetch-ec2-instance-type-info.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Calls EC2 describe-instance-types to form a json file used by the Spark container for choosing Spark config.
+# This will fetch more instance types than needed, but that's OK.
+
+set -euo pipefail
+
+source scripts/shared.sh
+
+parse_std_args "$@"
+
+dest_path=${build_context}/aws-config
+mkdir -p ${dest_path}
+dest_path=${dest_path}/ec2-instance-type-info.json
+
+echo "Fetching EC2 instance type info to ${dest_path} ..."
+aws ec2 describe-instance-types --region ${aws_region} | \
+  jq -c '[.InstanceTypes[] |
+  {
+    InstanceType: .InstanceType,
+    VCpuInfo: .VCpuInfo,
+    MemoryInfo: .MemoryInfo,
+    GpuInfo: .GpuInfo
+  }] |
+  sort_by(.InstanceType)' > ${dest_path}

--- a/spark/processing/2.4/py3/docker/Dockerfile.cpu
+++ b/spark/processing/2.4/py3/docker/Dockerfile.cpu
@@ -49,6 +49,7 @@ COPY *.whl /opt/program/
 RUN /usr/bin/python3 -m pip install /opt/program/*.whl
 COPY hadoop-config /opt/hadoop-config
 COPY nginx-config /opt/nginx-config
+COPY aws-config /opt/aws-config
 
 # With this config, spark history server will not run as daemon, otherwise there
 # will be no server running and container will terminate immediately

--- a/spark/processing/2.4/py3/hadoop-config/spark-defaults.conf
+++ b/spark/processing/2.4/py3/hadoop-config/spark-defaults.conf
@@ -1,3 +1,2 @@
 spark.driver.host=sd_host
-spark.executor.memory=exec_mem
-spark.executor.cores=exec_cores
+spark.hadoop.mapreduce.fileoutputcommitter.algorithm.version=2

--- a/spark/processing/2.4/py3/hadoop-config/yarn-site.xml
+++ b/spark/processing/2.4/py3/hadoop-config/yarn-site.xml
@@ -2,36 +2,6 @@
 <!-- Site specific YARN configuration properties -->
  <configuration>
      <property>
-         <name>yarn.scheduler.minimum-allocation-mb</name>
-         <value>minimum_allocation_mb</value>
-         <description>Minimum limit of memory to allocate to each container request at the Resource Manager.</description>
-     </property>
-     <property>
-         <name>yarn.scheduler.maximum-allocation-mb</name>
-         <value>maximum_allocation_mb</value>
-         <description>Maximum limit of memory to allocate to each container request at the Resource Manager.</description>
-     </property>
-     <property>
-         <name>yarn.scheduler.minimum-allocation-vcores</name>
-         <value>minimum_allocation_vcores</value>
-         <description>The minimum allocation for every container request at the RM, in terms of virtual CPU cores. Requests lower than this won't take effect, and the specified value will get allocated the minimum.</description>
-     </property>
-     <property>
-         <name>yarn.scheduler.maximum-allocation-vcores</name>
-         <value>maximum_allocation_vcores</value>
-         <description>The maximum allocation for every container request at the RM, in terms of virtual CPU cores. Requests higher than this won't take effect, and will get capped to this value.</description>
-     </property>
-     <property>
-         <name>yarn.nodemanager.resource.memory-mb</name>
-         <value>memory_mb_total</value>
-         <description>Physical memory, in MB, to be made available to running containers</description>
-     </property>
-     <property>
-         <name>yarn.nodemanager.resource.cpu-vcores</name>
-         <value>cpu_vcores_total</value>
-         <description>Number of CPU cores that can be allocated for containers.</description>
-     </property>
-     <property>
          <name>yarn.resourcemanager.hostname</name>
          <value>rm_hostname</value>
          <description>The hostname of the RM.</description>

--- a/test/unit/test_bootstrapper.py
+++ b/test/unit/test_bootstrapper.py
@@ -1,5 +1,5 @@
-from unittest.mock import MagicMock, Mock, call, patch
-
+from unittest.mock import MagicMock, Mock, PropertyMock, call, mock_open, patch
+import json
 import pytest
 from smspark.bootstrapper import Bootstrapper
 from smspark.config import Configuration
@@ -199,3 +199,183 @@ def test_spark_standalone_primary(patched_popen, default_bootstrapper) -> None:
     default_bootstrapper.start_spark_standalone_primary()
 
     patched_popen.assert_called_once_with("/usr/lib/spark/sbin/start-master.sh", shell=True)
+
+
+@patch("os.path.exists")
+def test_load_processing_job_config(patched_exists, default_bootstrapper: Bootstrapper) -> None:
+    exp_config = {"ProcessingResources": {"ClusterConfig": {"InstanceType": "foo.xbar", "InstanceCount": 123}}}
+
+    patched_exists.return_value = True
+    with patch("smspark.bootstrapper.open", mock_open(read_data=json.dumps(exp_config))) as m:
+        actual_config = default_bootstrapper.load_processing_job_config()
+    assert actual_config == exp_config
+    patched_exists.assert_called_once_with(Bootstrapper.PROCESSING_JOB_CONFIG_PATH)
+    m.assert_called_once_with(Bootstrapper.PROCESSING_JOB_CONFIG_PATH, "r")
+
+
+@patch("os.path.exists")
+def test_load_processing_job_config_fallback(patched_exists, default_bootstrapper: Bootstrapper) -> None:
+    patched_exists.return_value = False
+    assert default_bootstrapper.load_processing_job_config() is None
+    patched_exists.assert_called_once_with(Bootstrapper.PROCESSING_JOB_CONFIG_PATH)
+
+
+@patch("os.path.exists")
+def test_load_instance_type_info(patched_exists, default_bootstrapper: Bootstrapper) -> None:
+    raw_config = [
+        {"InstanceType": "foo.xlarge", "foo": "bar"},
+        {
+            "InstanceType": "bar.xlarge",
+            "bar": "foo",
+        },
+    ]
+    exp_config = {"foo.xlarge": {"foo": "bar"}, "bar.xlarge": {"bar": "foo"}}
+
+    patched_exists.return_value = True
+    with patch("smspark.bootstrapper.open", mock_open(read_data=json.dumps(raw_config))) as m:
+        actual_config = default_bootstrapper.load_instance_type_info()
+    assert actual_config == exp_config
+    patched_exists.assert_called_once_with(Bootstrapper.INSTANCE_TYPE_INFO_PATH)
+    m.assert_called_once_with(Bootstrapper.INSTANCE_TYPE_INFO_PATH, "r")
+
+
+@patch("os.path.exists")
+def test_load_instance_type_info(patched_exists, default_bootstrapper: Bootstrapper) -> None:
+    patched_exists.return_value = False
+    assert default_bootstrapper.load_instance_type_info() is None
+    patched_exists.assert_called_once_with(Bootstrapper.INSTANCE_TYPE_INFO_PATH)
+
+
+@patch("smspark.config.Configuration")
+@patch("smspark.config.Configuration")
+def test_set_yarn_spark_resource_config(
+    patched_yarn_config, patched_spark_config, default_bootstrapper: Bootstrapper
+) -> None:
+    processing_job_config = {
+        "ProcessingResources": {"ClusterConfig": {"InstanceType": "foo.xbar", "InstanceCount": 123}}
+    }
+    instance_type_info = {"foo.xbar": {"MemoryInfo": {"SizeInMiB": 456}, "VCpuInfo": {"DefaultVCpus": 789}}}
+    default_bootstrapper.load_processing_job_config = MagicMock(return_value=processing_job_config)
+    default_bootstrapper.load_instance_type_info = MagicMock(return_value=instance_type_info)
+    default_bootstrapper.get_yarn_spark_resource_config = MagicMock(
+        return_value=(patched_yarn_config, patched_spark_config)
+    )
+
+    default_bootstrapper.set_yarn_spark_resource_config()
+
+    default_bootstrapper.load_processing_job_config.assert_called_once()
+    default_bootstrapper.load_instance_type_info.assert_called_once()
+    default_bootstrapper.get_yarn_spark_resource_config.assert_called_once_with(123, 456, 789)
+    patched_yarn_config.write_config.assert_called_once()
+    patched_spark_config.write_config.assert_called_once()
+
+
+@patch("smspark.config.Configuration")
+@patch("smspark.config.Configuration")
+@patch("psutil.cpu_count")
+@patch("psutil.virtual_memory")
+def test_set_yarn_spark_resource_config_fallback(
+    patched_virtual_memory,
+    patched_cpu_count,
+    patched_yarn_config,
+    patched_spark_config,
+    default_bootstrapper: Bootstrapper,
+) -> None:
+    mocked_virtual_memory_total = PropertyMock(return_value=123 * 1024 * 1024)
+    type(patched_virtual_memory.return_value).total = mocked_virtual_memory_total
+    patched_cpu_count.return_value = 456
+
+    default_bootstrapper.load_processing_job_config = MagicMock(return_value=None)
+    default_bootstrapper.load_instance_type_info = MagicMock(return_value=None)
+    default_bootstrapper.get_yarn_spark_resource_config = MagicMock(
+        return_value=(patched_yarn_config, patched_spark_config)
+    )
+
+    default_bootstrapper.set_yarn_spark_resource_config()
+
+    patched_virtual_memory.assert_called_once()
+    mocked_virtual_memory_total.assert_called_once()
+    patched_cpu_count.assert_called_once()
+
+    default_bootstrapper.load_processing_job_config.assert_called_once()
+    default_bootstrapper.load_instance_type_info.assert_called_once()
+    default_bootstrapper.get_yarn_spark_resource_config.assert_called_once_with(1, 123, 456)
+    patched_yarn_config.write_config.assert_called_once()
+    patched_spark_config.write_config.assert_called_once()
+
+
+def test_get_yarn_spark_resource_config(default_bootstrapper: Bootstrapper) -> None:
+    # Using a cluster with one single m5.xlarge instance, calculate Yarn and Spark configs, and double check the math
+    instance_mem_mb = 16384
+    instance_cores = 4
+    yarn_config, spark_config = default_bootstrapper.get_yarn_spark_resource_config(1, instance_mem_mb, instance_cores)
+
+    exp_yarn_max_mem_mb = 15892  # = int(instance_mem_mb * .97) = int(16384 * .97) = int(15892.48)
+
+    exp_yarn_config_props = {
+        "yarn.scheduler.minimum-allocation-mb": "1",
+        "yarn.scheduler.maximum-allocation-mb": str(exp_yarn_max_mem_mb),
+        "yarn.scheduler.minimum-allocation-vcores": "1",
+        "yarn.scheduler.maximum-allocation-vcores": str(instance_cores),
+        "yarn.nodemanager.resource.memory-mb": str(exp_yarn_max_mem_mb),
+        "yarn.nodemanager.resource.cpu-vcores": str(instance_cores),
+    }
+
+    assert yarn_config.Classification == "yarn-site"
+    assert yarn_config.Properties == exp_yarn_config_props
+
+    exp_executor_cores = 4  # = instance_cores = 4
+    exp_executor_count_total = 1  # = instance_count * executor_count_per_instance = 1 * 1
+    exp_default_parallelism = 8  # = instance_count * instance_cores * 2 = 1 * 4 * 2
+
+    exp_driver_mem_mb = 2048  # = 2 * 1024
+    exp_driver_mem_ovr_mb = 204  # = int(driver_mem_mb * driver_mem_ovr_pct) = int(2048 * 0.1) = int(204.8)
+    # = int((instance_mem_mb - driver_mem_mb - driver_mem_ovr_mb) /
+    #       (executor_count_per_instance + executor_count_per_instance * executor_mem_ovr_pct))
+    # = int((15892 - 2048 - 204) / (1 + 1 * 0.1))
+    # = int(13640 / 1.1)
+    exp_executor_mem_mb = 12399
+    exp_executor_mem_ovr_mb = 1239  # = int(executor_mem_mb * executor_mem_ovr_pct) = int(12399 * 0.1) = int(1239.9)
+
+    exp_driver_gc_config = (
+        "-XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=70 -XX:MaxHeapFreeRatio=70 "
+        "-XX:+CMSClassUnloadingEnabled"
+    )
+    exp_driver_java_opts = "-XX:OnOutOfMemoryError='kill -9 %p' " f"{exp_driver_gc_config}"
+
+    # ConcGCThreads = max(int(executor_cores / 4), 1) = max(int(4 / 4), 1) = max(1, 1) = 1
+    # ParallelGCThreads = max(int(3 * executor_cores / 4), 1) = max(int(3 * 4 / 4), 1) = max(3, 1) = 3
+    exp_executor_gc_config = (
+        "-XX:+UseParallelGC -XX:InitiatingHeapOccupancyPercent=70 " "-XX:ConcGCThreads=1 " "-XX:ParallelGCThreads=3 "
+    )
+    exp_executor_java_opts = (
+        "-verbose:gc -XX:OnOutOfMemoryError='kill -9 %p' "
+        "-XX:+PrintGCDetails -XX:+PrintGCDateStamps "
+        f"{exp_executor_gc_config}"
+    )
+
+    exp_spark_config_props = {
+        "spark.driver.memory": f"{exp_driver_mem_mb}m",
+        "spark.driver.memoryOverhead": f"{exp_driver_mem_ovr_mb}m",
+        "spark.driver.defaultJavaOptions": f"{exp_driver_java_opts}m",
+        "spark.executor.memory": f"{exp_executor_mem_mb}m",
+        "spark.executor.memoryOverhead": f"{exp_executor_mem_ovr_mb}m",
+        "spark.executor.cores": f"{exp_executor_cores}",
+        "spark.executor.defaultJavaOptions": f"{exp_executor_java_opts}",
+        "spark.executor.instances": f"{exp_executor_count_total}",
+        "spark.default.parallelism": f"{exp_default_parallelism}",
+    }
+
+    assert spark_config.Classification == "spark-defaults"
+    assert spark_config.Properties == exp_spark_config_props
+
+    # Using the same instance type, increase the instance count by 10x
+    yarn_config, spark_config = default_bootstrapper.get_yarn_spark_resource_config(10, instance_mem_mb, instance_cores)
+
+    # Yarn config should be the same
+    assert yarn_config.Properties == exp_yarn_config_props
+
+    # Spark config should be the same with more 10x executors and parallelism
+    exp_spark_config_props["spark.executor.instances"] = f"{exp_executor_count_total * 10}"
+    exp_spark_config_props["spark.default.parallelism"] = f"{exp_default_parallelism * 10}"
+    assert spark_config.Properties == exp_spark_config_props


### PR DESCRIPTION
Add build-time script to fetch EC2 instance type info config file
Bootstrapper checks instance type/count info to compute and set Spark and Yarn configs
Basic strategy is 1 executor per instance using all available cores and memory, minus 2GB for driver memory

*Issue #, if available:*
* CR: CR-32261468
* SIM: SM-PROCESSING-731

*Description of changes:*

This change allows the SM Spark container to set reasonable default configs on Spark and Yarn to maximize cluster resource utilization. We introduce a build-time script to query EC2 for latest instance metadata which is retained as a config file in the container image. At container runtime, the Bootstrapper class checks for SageMaker ProcessingJob metadata to determine instance count/type, and uses this to query instance type info like available memory and CPU cores. In case any of this metadata is missing, the Bootstrapper falls back to estimate available resources from `psutil`. Using all this info, the Bootstrapper calculates default resource configs for Spark and Yarn, borrowing heuristics from EMR, then writes these configs into respective config files (`spark-defaults.conf`, `yarn-site.xml`).

This change has been tested with all standard SM/Spark integration tests in this package, as well as a number of benchmark jobs using queries derived from TPC-DS. It is stable for the majority of instance types tested at 10G and 100G scale.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
