### PR TITLE
Override fs.s3a.endpoint for AWS GovCloud regions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,8 @@ test-local: install-sdk build-tests
 # Use pytest-parallel to run tests in parallel - https://pypi.org/project/pytest-parallel/
 test-sagemaker: install-sdk build-tests
 	# https://github.com/ansible/ansible/issues/32499#issuecomment-341578864
-	OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES pytest --workers auto -s -vv test/integration/sagemaker --repo=$(DEST_REPO) --tag=$(VERSION) --durations=0 \
+	OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES pytest --workers auto -s -vv test/integration/sagemaker \
+	--repo=$(DEST_REPO) --tag=$(VERSION) --durations=0 \
 	--role $(ROLE) \
 	--image_uri $(IMAGE_URI) \
 	--region ${REGION} \

--- a/src/smspark/bootstrapper.py
+++ b/src/smspark/bootstrapper.py
@@ -267,11 +267,14 @@ class Bootstrapper:
         elif aws_region in ["cn-northwest-1", "cn-north-1"]:
             aws_domain = "amazonaws.com.cn"
             s3_endpoint = f"s3.{aws_region}.{aws_domain}"
+        elif aws_region in ["us-gov-west-1", "us-gov-east-1"]:
+            aws_domain = "amazonaws.com"
+            s3_endpoint = f"s3.{aws_region}.{aws_domain}"
         else:
             # no special regional configs needed
             return []
 
-        return [Configuration(Classification="core-site", Properties={"fs.s3a.endpoint": s3_endpoint},)]
+        return [Configuration(Classification="core-site", Properties={"fs.s3a.endpoint": s3_endpoint})]
 
     def load_processing_job_config(self) -> Dict[str, Any]:
         if not os.path.exists(self.PROCESSING_JOB_CONFIG_PATH):

--- a/test/integration/sagemaker/test_spark_history_server.py
+++ b/test/integration/sagemaker/test_spark_history_server.py
@@ -7,7 +7,7 @@ from sagemaker.spark.processing import PySparkProcessor
 MAX_RETRIES = 10
 
 
-def test_history_server(tag, role, image_uri):
+def test_history_server(tag, role, image_uri, sagemaker_session):
     spark = PySparkProcessor(
         base_job_name="sm-spark",
         framework_version=tag,
@@ -16,15 +16,18 @@ def test_history_server(tag, role, image_uri):
         instance_count=1,
         instance_type="ml.c5.xlarge",
         max_runtime_in_seconds=1200,
+        sagemaker_session=sagemaker_session,
     )
-    bucket = spark.sagemaker_session.default_bucket()
+    bucket = sagemaker_session.default_bucket()
     spark_event_logs_key_prefix = "spark/spark-history-fs"
     spark_event_logs_s3_uri = "s3://{}/{}".format(bucket, spark_event_logs_key_prefix)
 
     with open("test/resources/data/files/sample_spark_event_logs") as data:
         body = data.read()
         S3Uploader.upload_string_as_file_body(
-            body=body, desired_s3_uri=spark_event_logs_s3_uri + "/sample_spark_event_logs"
+            body=body,
+            desired_s3_uri=spark_event_logs_s3_uri + "/sample_spark_event_logs",
+            sagemaker_session=sagemaker_session,
         )
 
     spark.start_history_server(spark_event_logs_s3_uri=spark_event_logs_s3_uri)

--- a/test/unit/test_bootstrapper.py
+++ b/test/unit/test_bootstrapper.py
@@ -229,6 +229,17 @@ def test_get_regional_configs_cn(patched_getenv, default_bootstrapper: Bootstrap
 
 
 @patch("os.getenv")
+def test_get_regional_configs_gov(patched_getenv, default_bootstrapper: Bootstrapper) -> None:
+    patched_getenv.return_value = "us-gov-west-1"
+    regional_configs_list = default_bootstrapper.get_regional_configs()
+    assert len(regional_configs_list) == 1
+    assert regional_configs_list[0] == Configuration(
+        Classification="core-site", Properties={"fs.s3a.endpoint": "s3.us-gov-west-1.amazonaws.com"}
+    )
+    patched_getenv.assert_called_once_with("AWS_REGION")
+
+
+@patch("os.getenv")
 def test_get_regional_configs_us(patched_getenv, default_bootstrapper: Bootstrapper) -> None:
     patched_getenv.return_value = "us-west-2"
     regional_configs_list = default_bootstrapper.get_regional_configs()


### PR DESCRIPTION
* Override fs.s3a.endpoint for AWS GovCloud regions
  * Plus small fix for test_spark_history_server to use regionalized sagemaker_session from pytest fixture

*Issue #, if available:*
N/A

*Description of changes:*

Quick follow-up after my PR#11 from yesterday (https://github.com/aws/sagemaker-spark-container/pull/11). I had not set overrides for the S3 endpoint in GovCloud regions, because it looked like GovCloud followed the same S3 endpoint pattern as other regions (see [S3 GovCloud doc](https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/using-govcloud-endpoints.html)). However when testing in us-gov-west-1 I found the Spark jobs failed with the same S3 400/Bad Request error related to wrong endpoint. By setting the endpoint explicitly we can avoid this error.

Tested by setting this same config property via Configuration override -- integ tests passed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
