### PR TITLE
Fix history server logging and set regional configs

### DIFF
--- a/sagemaker-python-sdk-spark/sagemaker/spark/processing.py
+++ b/sagemaker-python-sdk-spark/sagemaker/spark/processing.py
@@ -467,6 +467,9 @@ class _SparkProcessorBase(ScriptProcessor):
         else:
             history_server_env_variables.update(self._config_aws_credentials())
 
+        region = self.sagemaker_session.boto_region_name
+        history_server_env_variables["AWS_REGION"] = region
+
         return history_server_env_variables
 
     def _is_notebook_instance(self):

--- a/src/smspark/history_server_utils.py
+++ b/src/smspark/history_server_utils.py
@@ -29,13 +29,15 @@ def start_history_server(event_logs_s3_uri: str) -> None:
     bootstrapper.copy_aws_jars()
     log.info("copying cluster config")
     bootstrapper.copy_cluster_config()
+    log.info("setting regional configs")
+    bootstrapper.set_regional_configs()
     log.info("copying history server config")
     config_history_server(event_logs_s3_uri)
     log.info("bootstrap master node")
     bootstrapper.start_spark_standalone_primary()
 
     try:
-        subprocess.check_output("sbin/start-history-server.sh", stderr=subprocess.PIPE)
+        subprocess.run("sbin/start-history-server.sh", check=True)
     except subprocess.CalledProcessError as e:
         raise AlgorithmError(message=e.stderr.decode(sys.getfilesystemencoding()), caused_by=e, exit_code=e.returncode)
     except Exception as e:

--- a/test/unit/test_history_server_utils.py
+++ b/test/unit/test_history_server_utils.py
@@ -35,13 +35,14 @@ def test_config_history_server_without_env_variable():
 
 @patch("smspark.history_server_utils.config_history_server")
 @patch("smspark.history_server_utils.Bootstrapper")
-@patch("subprocess.check_output")
-def test_start_history_server(mock_subprocess_check_output, mock_bootstrapper, mock_config_history_server) -> None:
+@patch("subprocess.run")
+def test_start_history_server(mock_subprocess_run, mock_bootstrapper, mock_config_history_server) -> None:
     bootstrapper = MagicMock()
     mock_bootstrapper.return_value = bootstrapper
     start_history_server(SPARK_DEFAULTS_CONFIG_PATH)
     bootstrapper.start_spark_standalone_primary.assert_called_once()
     bootstrapper.copy_cluster_config.assert_called_once()
     bootstrapper.copy_aws_jars.assert_called_once()
+    bootstrapper.set_regional_configs.assert_called_once()
     mock_config_history_server.assert_called_once()
-    mock_subprocess_check_output.assert_called_once_with("sbin/start-history-server.sh", stderr=subprocess.PIPE)
+    mock_subprocess_run.assert_called_once_with("sbin/start-history-server.sh", check=True)


### PR DESCRIPTION
* Fix history server logging and set regional configs
  * Replace subprocess.check_output() with subprocess.run() to see full history server logs
  * Call bootstrapper.set_regional_configs() before running history server (requires env var AWS_REGION)
  * Py SDK sets history server env var AWS_REGION

*Issue #, if available:*

*Description of changes:*

This PR fixes some problems I encountered running the history server integ test case in PDT. We weren't getting all the logs from the history server process, so now using `subprocess.run()` which will pipe all logs to stdout in the parent process. With the extra logs we found the same S3 endpoint errors encountered before, so we need the alternate history server entrypoint to handle regional config bootstrapping too. I've made a quickfix in the local Py SDK to set AWS_REGION env var before starting the history server -- but to make this change permanent we will need to update the open [PR for Spark Processor in Py SDK](https://github.com/aws/sagemaker-python-sdk-staging/pull/328)

From what I understand, we've had the same problems in CN region CodeBuild tests. This change should solve the history server endpoint issue in CN and Gov regions.

*Testing:*
So far has been tested by building Spark container image locally, pushing to PDT repo, and running PDT CodeBuild-Test against my temporary branch [test-history-server](https://github.com/aws/sagemaker-spark-container/tree/test-history-server).

Will start the CodeBuild-Test run in PDX Alpha account.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
