### PR TITLE
Fix CLI quoting

### DIFF
--- a/src/smspark/cli.py
+++ b/src/smspark/cli.py
@@ -1,6 +1,7 @@
 """Entry-point for command-line commands."""
 import logging
 import pathlib
+import shlex
 import sys
 from typing import Any, Dict, Sequence
 from urllib.parse import urlparse
@@ -218,5 +219,5 @@ def _construct_spark_submit_command(spark_opts: Dict[str, Any], app_and_app_argu
     cmd = ["spark-submit", "--master", "yarn", "--deploy-mode", "client"]
     cmd.extend(spark_options_list)
     cmd.extend(app_and_app_arguments)
-    cmd_string = " ".join(c for c in cmd)
+    cmd_string = " ".join(shlex.quote(c) for c in cmd)
     return cmd_string

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -135,6 +135,16 @@ def get_test_cases() -> List[SubmitTest]:
         ),
     ] + test_cases
 
+    # Quote tests:
+
+    test_cases.append(
+        SubmitTest(
+            name="quotes are handled correctly",
+            args="--jars {jar_file} myscript.py --query-bbox 'BBOX(geometry,0.1,-0.2,3.3,4.5)' --query-start-date '2020-05-01 00:00:00' --query-end-date '2020-05-31 23:59:59' --data-location-uri s3://123456789012-us-west-2/path --bucket-region us-west-2 --output-folder-path /opt/ml/processing/output/out --output-stage gamma --storage-bucket-uri s3://123456789012-us-west-2/",
+            expected_cmd="spark-submit --master yarn --deploy-mode client --jars {jar_file} myscript.py --query-bbox 'BBOX(geometry,0.1,-0.2,3.3,4.5)' --query-start-date '2020-05-01 00:00:00' --query-end-date '2020-05-31 23:59:59' --data-location-uri s3://123456789012-us-west-2/path --bucket-region us-west-2 --output-folder-path /opt/ml/processing/output/out --output-stage gamma --storage-bucket-uri s3://123456789012-us-west-2/",
+        )
+    )
+
     return test_cases
 
 


### PR DESCRIPTION
*Issue #, if available:*

Fixes an issue with shell quoting, reported by an internal customer

*Description of changes:*

Use [shlex.quote](https://docs.python.org/3/library/shlex.html#shlex.quote) to shell-escape CLI args

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
