### PR TITLE
Fix in spark history server test not to return None

### DIFF
--- a/test/integration/sagemaker/test_spark_history_server.py
+++ b/test/integration/sagemaker/test_spark_history_server.py
@@ -74,7 +74,4 @@ def _request_with_retry(url, max_retries=10):
             max_retries, redirect=max_retries, status=max_retries, status_forcelist=[502, 404], backoff_factor=0.2,
         )
     )
-    try:
-        return http.request("GET", url)
-    except Exception:  # pylint: disable=W0703
-        return None
+    return http.request("GET", url)


### PR DESCRIPTION
*Issue #, if available:*

Removing this try / except block -- when this returns none, it masks the cause of failure. "None" doesn't have a `status` attribute.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
