### PR TITLE
add default tag integration test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,8 @@ test-sagemaker: install-sdk build-tests
 	# History server tests can't run in parallel since they use the same container name.
 	pytest -s -vv test/integration/history \
 	--repo=$(DEST_REPO) --tag=$(VERSION) --durations=0 \
+	--spark-version=$(SPARK_VERSION)
+	--framework_version=$(FRAMEWORK_VERSION) \
 	--role $(ROLE) \
 	--image_uri $(IMAGE_URI) \
 	--region ${REGION} \
@@ -91,6 +93,20 @@ test-sagemaker: install-sdk build-tests
 	# OBJC_DISABLE_INITIALIZE_FORK_SAFETY: https://github.com/ansible/ansible/issues/32499#issuecomment-341578864
 	OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES pytest --workers auto -s -vv test/integration/sagemaker \
 	--repo=$(DEST_REPO) --tag=$(VERSION) --durations=0 \
+	--spark-version=$(SPARK_VERSION)
+	--framework_version=$(FRAMEWORK_VERSION) \
+	--role $(ROLE) \
+	--image_uri $(IMAGE_URI) \
+	--region ${REGION} \
+	--domain ${AWS_DOMAI Run default tag integration testN}
+
+#
+# This is included in a separate target because it will be run only in prod stage
+test-tag:
+	pytest -s -vv test/integration/tag \
+	--repo=$(DEST_REPO) --tag=$(VERSION) --durations=0 \
+	--spark-version=$(SPARK_VERSION)
+	--framework_version=$(FRAMEWORK_VERSION) \
 	--role $(ROLE) \
 	--image_uri $(IMAGE_URI) \
 	--region ${REGION} \

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -23,6 +23,8 @@ def pytest_addoption(parser) -> str:
     parser.addoption("--region", default="us-west-2")
     parser.addoption("--repo")
     parser.addoption("--tag")
+    parser.addoption("--spark-version")
+    parser.addoption("--framework-version")
     parser.addoption("--domain", default="amazonaws.com")
 
 
@@ -58,6 +60,18 @@ def repo(request) -> str:
 def tag(request) -> str:
     """Return Docker image tag to use in tests."""
     return request.config.getoption("--tag")
+
+
+@pytest.fixture(scope="session")
+def spark_version(request) -> str:
+    """Return Docker image framework_version to use in tests."""
+    return request.config.getoption("--spark-version")
+
+
+@pytest.fixture(scope="session")
+def framework_version(request) -> str:
+    """Return Docker image framework_version to use in tests."""
+    return request.config.getoption("--framework-version")
 
 
 @pytest.fixture(scope="session")

--- a/test/integration/local/test_multinode_container.py
+++ b/test/integration/local/test_multinode_container.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import subprocess
+
 import pytest
 
 

--- a/test/integration/sagemaker/test_spark.py
+++ b/test/integration/sagemaker/test_spark.py
@@ -91,11 +91,10 @@ def configuration() -> list:
     return configuration
 
 
-def test_sagemaker_pyspark_multinode(tag, role, image_uri, configuration, sagemaker_session, region, sagemaker_client):
+def test_sagemaker_pyspark_multinode(role, image_uri, configuration, sagemaker_session, region, sagemaker_client):
     """Test that basic multinode case works on 32KB of data"""
     spark = PySparkProcessor(
         base_job_name="sm-spark-py",
-        framework_version=tag,
         image_uri=image_uri,
         role=role,
         instance_count=2,
@@ -168,11 +167,10 @@ def test_sagemaker_pyspark_multinode(tag, role, image_uri, configuration, sagema
 # TODO: similar integ test case for SSE-KMS. This would require test infrastructure bootstrapping a KMS key.
 # Currently, Spark jobs can read data encrypted with SSE-KMS (assuming the execution role has permission),
 # however our Hadoop version (2.8.5) does not support writing data with SSE-KMS (enabled in version 3.0.0).
-def test_sagemaker_pyspark_sse_s3(tag, role, image_uri, sagemaker_session, region, sagemaker_client):
+def test_sagemaker_pyspark_sse_s3(role, image_uri, sagemaker_session, region, sagemaker_client):
     """Test that Spark container can read and write S3 data encrypted with SSE-S3 (default AES256 encryption)"""
     spark = PySparkProcessor(
         base_job_name="sm-spark-py",
-        framework_version=tag,
         image_uri=image_uri,
         role=role,
         instance_count=2,
@@ -212,11 +210,10 @@ def test_sagemaker_pyspark_sse_s3(tag, role, image_uri, sagemaker_session, regio
     assert len(output_contents) != 0
 
 
-def test_sagemaker_scala_jar_multinode(tag, role, image_uri, configuration, sagemaker_session, sagemaker_client):
+def test_sagemaker_scala_jar_multinode(role, image_uri, configuration, sagemaker_session, sagemaker_client):
     """Test SparkJarProcessor using Scala application jar with external runtime dependency jars staged by SDK"""
     spark = SparkJarProcessor(
         base_job_name="sm-spark-scala",
-        framework_version=tag,
         image_uri=image_uri,
         role=role,
         instance_count=2,
@@ -257,11 +254,10 @@ def test_sagemaker_scala_jar_multinode(tag, role, image_uri, configuration, sage
     assert len(output_contents) != 0
 
 
-def test_sagemaker_java_jar_multinode(tag, role, image_uri, configuration, sagemaker_session, sagemaker_client):
+def test_sagemaker_java_jar_multinode(role, image_uri, configuration, sagemaker_session, sagemaker_client):
     """Test SparkJarProcessor using Java application jar"""
     spark = SparkJarProcessor(
         base_job_name="sm-spark-java",
-        framework_version=tag,
         image_uri=image_uri,
         role=role,
         instance_count=2,

--- a/test/integration/tag/test_default_tag.py
+++ b/test/integration/tag/test_default_tag.py
@@ -1,0 +1,60 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from datetime import datetime
+
+from sagemaker.s3 import S3Downloader, S3Uploader
+from sagemaker.spark.processing import PySparkProcessor
+
+
+def test_sagemaker_spark_processor_default_tag(spark_version, role, sagemaker_session, sagemaker_client):
+    """Test that spark processor works with default tag"""
+    spark = PySparkProcessor(
+        base_job_name="sm-spark-py",
+        framework_version=spark_version,
+        role=role,
+        instance_count=1,
+        instance_type="ml.c5.xlarge",
+        max_runtime_in_seconds=1200,
+        sagemaker_session=sagemaker_session,
+    )
+    bucket = spark.sagemaker_session.default_bucket()
+    timestamp = datetime.now().isoformat()
+    output_data_uri = "s3://{}/spark/output/sales/{}".format(bucket, timestamp)
+    spark_event_logs_key_prefix = "spark/spark-events/{}".format(timestamp)
+    spark_event_logs_s3_uri = "s3://{}/{}".format(bucket, spark_event_logs_key_prefix)
+
+    with open("test/resources/data/files/data.jsonl") as data:
+        body = data.read()
+        input_data_uri = "s3://{}/spark/input/data.jsonl".format(bucket)
+        S3Uploader.upload_string_as_file_body(
+            body=body, desired_s3_uri=input_data_uri, sagemaker_session=sagemaker_session
+        )
+
+    spark.run(
+        submit_app="test/resources/code/python/hello_py_spark/hello_py_spark_app.py",
+        submit_py_files=["test/resources/code/python/hello_py_spark/hello_py_spark_udfs.py"],
+        arguments=["--input", input_data_uri, "--output", output_data_uri],
+        spark_event_logs_s3_uri=spark_event_logs_s3_uri,
+        wait=True,
+    )
+
+    processing_job = spark.latest_job
+    waiter = sagemaker_client.get_waiter("processing_job_completed_or_stopped")
+    waiter.wait(
+        ProcessingJobName=processing_job.job_name,
+        # poll every 15 seconds. timeout after 15 minutes.
+        WaiterConfig={"Delay": 15, "MaxAttempts": 60},
+    )
+
+    output_contents = S3Downloader.list(output_data_uri, sagemaker_session=sagemaker_session)
+    assert len(output_contents) != 0


### PR DESCRIPTION
*Issue #, if available:*
In python sdk, customers can specify the spark container with either image_uri or framework_version. With just framework_version, an default tag of the image will be used(e.g, 2.4-cpu). Currently all integration tests are using image_uri directly, need an integration test to test default tag.

*Description of changes:*
Add integration test for default tag by just specifying framework_version.

Create a new target because this new integration test will only be running for prod stages. The reason being that Sagemaker python sdk is responsible for building the default tag by maintaining a json file that has a map between only regions and prod accounts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
