### PR TITLE
generalize copy_aws_jar and upgrade emr 5.31.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,8 +84,8 @@ test-sagemaker: install-sdk build-tests
 	# History server tests can't run in parallel since they use the same container name.
 	pytest -s -vv test/integration/history \
 	--repo=$(DEST_REPO) --tag=$(VERSION) --durations=0 \
-	--spark-version=$(SPARK_VERSION)
-	--framework_version=$(FRAMEWORK_VERSION) \
+	--spark-version=$(SPARK_VERSION) \
+	--framework-version=$(FRAMEWORK_VERSION) \
 	--role $(ROLE) \
 	--image_uri $(IMAGE_URI) \
 	--region ${REGION} \
@@ -93,9 +93,10 @@ test-sagemaker: install-sdk build-tests
 	# OBJC_DISABLE_INITIALIZE_FORK_SAFETY: https://github.com/ansible/ansible/issues/32499#issuecomment-341578864
 	OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES pytest --workers auto -s -vv test/integration/sagemaker \
 	--repo=$(DEST_REPO) --tag=$(VERSION) --durations=0 \
-	--spark-version=$(SPARK_VERSION)
-	--framework_version=$(FRAMEWORK_VERSION) \
+	--spark-version=$(SPARK_VERSION) \
+	--framework-version=$(FRAMEWORK_VERSION) \
 	--role $(ROLE) \
+	--account-id ${INTEG_TEST_ACCOUNT} \
 	--image_uri $(IMAGE_URI) \
 	--region ${REGION} \
 	--domain ${AWS_DOMAIN}
@@ -105,7 +106,7 @@ test-prod:
 	pytest -s -vv test/integration/tag \
 	--repo=$(DEST_REPO) --tag=$(VERSION) --durations=0 \
 	--spark-version=$(SPARK_VERSION)
-	--framework_version=$(FRAMEWORK_VERSION) \
+	--framework-version=$(FRAMEWORK_VERSION) \
 	--role $(ROLE) \
 	--image_uri $(IMAGE_URI) \
 	--region ${REGION} \

--- a/new_images.yml
+++ b/new_images.yml
@@ -1,7 +1,7 @@
 ---
 new_images:
-  - spark: "2.4.4"
+  - spark: "2.4.6"
     use-case: "processing"
     processors: ["cpu"]
     python: ["py37"]
-    sm_version: "1.0"
+    sm_version: "1.2"

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     ],
     setup_requires=["setuptools", "wheel"],
     # Be frugal when adding dependencies. Prefer Python's standard library.
-    install_requires = install_reqs,
+    install_requires=install_reqs,
 
     extras_require={
         "test": test_install_reqs,

--- a/spark/processing/2.4/py3/container-bootstrap-config/bootstrap.sh
+++ b/spark/processing/2.4/py3/container-bootstrap-config/bootstrap.sh
@@ -1,0 +1,1 @@
+echo "Not implemented"

--- a/spark/processing/2.4/py3/docker/Dockerfile.cpu
+++ b/spark/processing/2.4/py3/docker/Dockerfile.cpu
@@ -85,6 +85,11 @@ COPY hadoop-config /opt/hadoop-config
 COPY nginx-config /opt/nginx-config
 COPY aws-config /opt/aws-config
 
+# Setup container bootstrapper
+COPY container-bootstrap-config /opt/container-bootstrap-config
+RUN chmod +x /opt/container-bootstrap-config/bootstrap.sh
+RUN /opt/container-bootstrap-config/bootstrap.sh
+
 # With this config, spark history server will not run as daemon, otherwise there
 # will be no server running and container will terminate immediately
 ENV SPARK_NO_DAEMONIZE TRUE

--- a/spark/processing/2.4/py3/yum/emr-apps.repo
+++ b/spark/processing/2.4/py3/yum/emr-apps.repo
@@ -1,7 +1,7 @@
 [emr-apps]
 name = EMR Application Repository
-gpgkey = https://s3-REGION.amazonaws.com/repo.REGION.emr.amazonaws.com/apps-repository/emr-5.30.1/82e3c3dd-2d53-4782-9e61-5f72ba3690c5/repoPublicKey.txt
+gpgkey = https://s3-REGION.amazonaws.com/repo.REGION.emr.amazonaws.com/apps-repository/emr-5.31.0/a75d77c7-f528-4266-b091-275dae889395/repoPublicKey.txt
 enabled = 1
-baseurl = https://s3-REGION.amazonaws.com/repo.REGION.emr.amazonaws.com/apps-repository/emr-5.30.1/82e3c3dd-2d53-4782-9e61-5f72ba3690c5
+baseurl = https://s3-REGION.amazonaws.com/repo.REGION.emr.amazonaws.com/apps-repository/emr-5.31.0/a75d77c7-f528-4266-b091-275dae889395
 priority = 5
 gpgcheck = 0

--- a/src/smspark/bootstrapper.py
+++ b/src/smspark/bootstrapper.py
@@ -44,6 +44,11 @@ class Bootstrapper:
     INSTANCE_TYPE_INFO_PATH = "/opt/aws-config/ec2-instance-type-info.json"
     EMR_CONFIGURE_APPS_URL = "https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-configure-apps.html"
     JAR_DEST = SPARK_PATH + "/jars"
+
+    # jets3t-0.9.0.jar is used by hadoop 2.8.5(https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-common)
+    # and 2.10.0(https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-common/2.10.0). However, it's not
+    # needed in 3.2.1 (https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-common/3.2.1)
+    # TODO: use a map with spark version as the key to maintain the optional jars
     OPTIONAL_JARS = {"jets3t-0.9.0.jar": HADOOP_PATH + "/lib"}
 
     def __init__(self, resource_config: Dict[str, Any] = default_resource_config):
@@ -80,6 +85,7 @@ class Bootstrapper:
         for f in glob.glob("/usr/share/aws/hmclient/lib/*.jar"):
             shutil.copyfile(f, os.path.join(self.JAR_DEST, os.path.basename(f)))
 
+    # TODO: use glob.glob
     def _get_hadoop_jar(self) -> str:
         for file_name in os.listdir(Bootstrapper.HADOOP_PATH):
             if file_name.startswith("hadoop-aws") and file_name.endswith(".jar"):

--- a/src/smspark/bootstrapper.py
+++ b/src/smspark/bootstrapper.py
@@ -19,12 +19,13 @@ import pathlib
 import shutil
 import socket
 import subprocess
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, List, Sequence, Tuple, Union
 
 import psutil
 import requests
 from smspark.config import Configuration
 from smspark.defaults import default_resource_config
+from smspark.errors import AlgorithmError
 from smspark.waiter import Waiter
 
 
@@ -36,11 +37,14 @@ class Bootstrapper:
     HADOOP_CONFIG_PATH = "/opt/hadoop-config/"
     HADOOP_PATH = "/usr/lib/hadoop"
     SPARK_PATH = "/usr/lib/spark"
+
     HIVE_PATH = "/usr/lib/hive"
     PROCESSING_CONF_INPUT_PATH = "/opt/ml/processing/input/conf/configuration.json"
     PROCESSING_JOB_CONFIG_PATH = "/opt/ml/config/processingjobconfig.json"
     INSTANCE_TYPE_INFO_PATH = "/opt/aws-config/ec2-instance-type-info.json"
     EMR_CONFIGURE_APPS_URL = "https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-configure-apps.html"
+    JAR_DEST = SPARK_PATH + "/jars"
+    OPTIONAL_JARS = {"jets3t-0.9.0.jar": HADOOP_PATH + "/lib"}
 
     def __init__(self, resource_config: Dict[str, Any] = default_resource_config):
         logging.basicConfig(level=logging.INFO)
@@ -63,28 +67,42 @@ class Bootstrapper:
 
     def copy_aws_jars(self) -> None:
         self.logger.info("copying aws jars")
-        jar_dest = Bootstrapper.SPARK_PATH + "/jars"
         for f in glob.glob("/usr/share/aws/aws-java-sdk/*.jar"):
-            shutil.copyfile(f, os.path.join(jar_dest, os.path.basename(f)))
-        hadoop_aws_jar = "hadoop-aws-2.8.5-amzn-6.jar"
-        jets3t_jar = "jets3t-0.9.0.jar"
+            shutil.copyfile(f, os.path.join(self.JAR_DEST, os.path.basename(f)))
+        hadoop_aws_jar = self._get_hadoop_jar()
         shutil.copyfile(
-            os.path.join(Bootstrapper.HADOOP_PATH, hadoop_aws_jar), os.path.join(jar_dest, hadoop_aws_jar),
+            os.path.join(Bootstrapper.HADOOP_PATH, hadoop_aws_jar), os.path.join(self.JAR_DEST, hadoop_aws_jar)
         )
-        # this jar required for using s3a client
-        shutil.copyfile(
-            os.path.join(Bootstrapper.HADOOP_PATH + "/lib", jets3t_jar), os.path.join(jar_dest, jets3t_jar),
-        )
+
+        self._copy_optional_jars()
         # copy hmclient (glue data catalog hive metastore client) jars to classpath:
         # https://github.com/awslabs/aws-glue-data-catalog-client-for-apache-hive-metastore
         for f in glob.glob("/usr/share/aws/hmclient/lib/*.jar"):
-            shutil.copyfile(f, os.path.join(jar_dest, os.path.basename(f)))
+            shutil.copyfile(f, os.path.join(self.JAR_DEST, os.path.basename(f)))
+
+    def _get_hadoop_jar(self) -> str:
+        for file_name in os.listdir(Bootstrapper.HADOOP_PATH):
+            if file_name.startswith("hadoop-aws") and file_name.endswith(".jar"):
+                self.logger.info(f"Found hadoop jar {file_name}")
+                return file_name
+
+        raise AlgorithmError("Error finding hadoop jar", caused_by=FileNotFoundError())
+
+    def _copy_optional_jars(self) -> None:
+        for jar, jar_path in self.OPTIONAL_JARS.items():
+            if os.path.isfile(os.path.join(jar_path, jar)):
+                self.logger.info(f"Copying optional jar {jar} from {jar_path} to {self.JAR_DEST}")
+                shutil.copyfile(
+                    os.path.join(jar_path, jar), os.path.join(self.JAR_DEST, jar),
+                )
+            else:
+                self.logger.info(f"Optional jar {jar} in {jar_path} does not exist")
 
     def copy_cluster_config(self) -> None:
         self.logger.info("copying cluster config")
 
         def copy_config(src: str, dst: str) -> None:
-            self.logger.info("copying {} to {}".format(src, dst))
+            self.logger.info(f"copying {src} to {dst}")
             shutil.copyfile(src, dst)
 
         copy_config(
@@ -395,7 +413,7 @@ class Bootstrapper:
             {
                 "spark.driver.memory": f"{driver_mem_mb}m",
                 "spark.driver.memoryOverhead": f"{driver_mem_ovr_mb}m",
-                "spark.driver.defaultJavaOptions": f"{driver_java_opts}m",
+                "spark.driver.defaultJavaOptions": f"{driver_java_opts}",
                 "spark.executor.memory": f"{executor_mem_mb}m",
                 "spark.executor.memoryOverhead": f"{executor_mem_ovr_mb}m",
                 "spark.executor.cores": f"{executor_cores}",

--- a/test/integration/sagemaker/test_spark.py
+++ b/test/integration/sagemaker/test_spark.py
@@ -210,6 +210,66 @@ def test_sagemaker_pyspark_sse_s3(role, image_uri, sagemaker_session, region, sa
     assert len(output_contents) != 0
 
 
+def test_sagemaker_pyspark_sse_kms_s3(role, image_uri, sagemaker_session, region, sagemaker_client, account_id):
+    spark = PySparkProcessor(
+        base_job_name="sm-spark-py",
+        image_uri=image_uri,
+        role=role,
+        instance_count=2,
+        instance_type="ml.c5.xlarge",
+        max_runtime_in_seconds=1200,
+        sagemaker_session=sagemaker_session,
+    )
+
+    kms_key_id = None
+    kms_client = sagemaker_session.boto_session.client("kms", region_name=region)
+    for alias in kms_client.list_aliases()["Aliases"]:
+        if "s3" in alias["AliasName"]:
+            kms_key_id = alias["TargetKeyId"]
+
+    if not kms_key_id:
+        raise ValueError("AWS managed s3 kms key(alias: aws/s3) does not exist")
+
+    bucket = sagemaker_session.default_bucket()
+    timestamp = datetime.now().isoformat()
+    input_data_key = f"spark/input/sales/{timestamp}/data.jsonl"
+    input_data_uri = f"s3://{bucket}/{input_data_key}"
+    output_data_uri_prefix = f"spark/output/sales/{timestamp}"
+    output_data_uri = f"s3://{bucket}/{output_data_uri_prefix}"
+    s3_client = sagemaker_session.boto_session.client("s3", region_name=region)
+    with open("test/resources/data/files/data.jsonl") as data:
+        body = data.read()
+        s3_client.put_object(
+            Body=body, Bucket=bucket, Key=input_data_key, ServerSideEncryption="aws:kms", SSEKMSKeyId=kms_key_id
+        )
+
+    spark.run(
+        submit_app="test/resources/code/python/hello_py_spark/hello_py_spark_app.py",
+        submit_py_files=["test/resources/code/python/hello_py_spark/hello_py_spark_udfs.py"],
+        arguments=["--input", input_data_uri, "--output", output_data_uri],
+        configuration={
+            "Classification": "core-site",
+            "Properties": {
+                "fs.s3a.server-side-encryption-algorithm": "SSE-KMS",
+                "fs.s3a.server-side-encryption.key": f"arn:aws:kms:{region}:{account_id}:key/{kms_key_id}",
+            },
+        },
+    )
+    processing_job = spark.latest_job
+    waiter = sagemaker_client.get_waiter("processing_job_completed_or_stopped")
+    waiter.wait(
+        ProcessingJobName=processing_job.job_name,
+        # poll every 15 seconds. timeout after 15 minutes.
+        WaiterConfig={"Delay": 15, "MaxAttempts": 60},
+    )
+    output_contents = S3Downloader.list(output_data_uri, sagemaker_session=sagemaker_session)
+    assert len(output_contents) != 0
+    for s3_object in s3_client.list_objects(Bucket=bucket, Prefix=output_data_uri_prefix)["Contents"]:
+        object_metadata = s3_client.get_object(Bucket=bucket, Key=s3_object["Key"])
+        assert object_metadata["ServerSideEncryption"] == "aws:kms"
+        assert object_metadata["SSEKMSKeyId"] == f"arn:aws:kms:{region}:{account_id}:key/{kms_key_id}"
+
+
 def test_sagemaker_scala_jar_multinode(role, image_uri, configuration, sagemaker_session, sagemaker_client):
     """Test SparkJarProcessor using Scala application jar with external runtime dependency jars staged by SDK"""
     spark = SparkJarProcessor(

--- a/test/unit/test_bootstrapper.py
+++ b/test/unit/test_bootstrapper.py
@@ -97,9 +97,11 @@ def test_env_classification(default_bootstrapper):
     assert output == expected
 
 
+@patch("os.listdir", return_value=["hadoop-aws-2.8.5-amzn-5.jar"])
+@patch("os.path.isfile", return_value=True)
 @patch("glob.glob", side_effect=[["/aws-sdk.jar"], ["/hmclient/lib/client.jar"]])
 @patch("shutil.copyfile", side_effect=None)
-def test_copy_aws_jars(patched_copyfile, patched_glob, default_bootstrapper) -> None:
+def test_copy_aws_jars(patched_copyfile, patched_glob, patched_isfile, patched_listdir, default_bootstrapper) -> None:
     default_bootstrapper.copy_aws_jars()
 
     expected = [
@@ -422,7 +424,7 @@ def test_get_yarn_spark_resource_config(default_bootstrapper: Bootstrapper) -> N
     exp_spark_config_props = {
         "spark.driver.memory": f"{exp_driver_mem_mb}m",
         "spark.driver.memoryOverhead": f"{exp_driver_mem_ovr_mb}m",
-        "spark.driver.defaultJavaOptions": f"{exp_driver_java_opts}m",
+        "spark.driver.defaultJavaOptions": f"{exp_driver_java_opts}",
         "spark.executor.memory": f"{exp_executor_mem_mb}m",
         "spark.executor.memoryOverhead": f"{exp_executor_mem_ovr_mb}m",
         "spark.executor.cores": f"{exp_executor_cores}",


### PR DESCRIPTION
Issue #, if available:
Spark container does not support sse-kms by s3a client with current hadoop version.

Description of changes:
Upgrade to emr 5.31.0 with Hadoop 2.10

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.