### PR TITLE
add init target in build-tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ build-test-scala:
 build-test-java:
 	cd test/resources/code/java/hello-java-spark; mvn package
 
-build-tests: build-test-scala build-test-java
+build-tests: init build-test-scala build-test-java
 
 lint: init
 	pipenv run black --check ./src


### PR DESCRIPTION
*Issue #, if available:*
rerun cannot be recognized without running make init

*Description of changes:*
add init target in build-tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
