### PR TITLE
Propagate env variable AWS_REGION to yarn

### DIFF
--- a/new_images.yml
+++ b/new_images.yml
@@ -1,6 +1,6 @@
 ---
 new_images:
-  - spark: "2.4.6"
+  - spark: "3.0.0"
     use-case: "processing"
     processors: ["cpu"]
     python: ["py37"]

--- a/src/smspark/bootstrapper.py
+++ b/src/smspark/bootstrapper.py
@@ -367,6 +367,7 @@ class Bootstrapper:
     def get_yarn_spark_resource_config(
         self, instance_count: int, instance_mem_mb: int, instance_cores: int
     ) -> Tuple[Configuration, Configuration]:
+        aws_region = os.getenv("AWS_REGION")
         executor_cores = instance_cores
         executor_count_per_instance = int(instance_cores / executor_cores)
         executor_count_total = instance_count * executor_count_per_instance
@@ -426,6 +427,8 @@ class Bootstrapper:
                 "spark.executor.defaultJavaOptions": f"{executor_java_opts}",
                 "spark.executor.instances": f"{executor_count_total}",
                 "spark.default.parallelism": f"{default_parallelism}",
+                "spark.yarn.appMasterEnv.AWS_REGION": f"{aws_region}",
+                "spark.executorEnv.AWS_REGION": f"{aws_region}"
             },
         )
 


### PR DESCRIPTION
*Issue #, if available:*

Got exception of SDK client that region cannot be found by the region provider. Processing container is forcing to run on yarn, and AWS_REGION's value is being set. However to make this variable visible to the yarn, spark conf needs to be explicitly set. After this change, tested by running a new job, it succeeded.

Reference:
https://spark.apache.org/docs/latest/configuration.html#environment-variables
https://stackoverflow.com/questions/47534642/setting-environment-variables-in-spark-cluster-mode

*Description of changes:*
Before submitting spark application, we set the value of AWS_REGION for yarn in the phase of bootstrap

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
