### PR TITLE
Whitelist AWS_REGION in yarn-site

### DIFF
--- a/spark/processing/2.4/py3/hadoop-config/yarn-site.xml
+++ b/spark/processing/2.4/py3/hadoop-config/yarn-site.xml
@@ -27,7 +27,7 @@
      </property>
      <property>
          <name>yarn.nodemanager.env-whitelist</name>
-         <value>JAVA_HOME,HADOOP_COMMON_HOME,HADOOP_HDFS_HOME,HADOOP_CONF_DIR,YARN_HOME,AWS_CONTAINER_CREDENTIALS_RELATIVE_URI</value>
+         <value>JAVA_HOME,HADOOP_COMMON_HOME,HADOOP_HDFS_HOME,HADOOP_CONF_DIR,YARN_HOME,AWS_CONTAINER_CREDENTIALS_RELATIVE_URI,AWS_REGION</value>
          <description>Environment variable whitelist</description>
      </property>
 

--- a/spark/processing/3.0/py3/hadoop-config/yarn-site.xml
+++ b/spark/processing/3.0/py3/hadoop-config/yarn-site.xml
@@ -27,7 +27,7 @@
      </property>
      <property>
          <name>yarn.nodemanager.env-whitelist</name>
-         <value>JAVA_HOME,HADOOP_COMMON_HOME,HADOOP_HDFS_HOME,HADOOP_CONF_DIR,YARN_HOME,AWS_CONTAINER_CREDENTIALS_RELATIVE_URI</value>
+         <value>JAVA_HOME,HADOOP_COMMON_HOME,HADOOP_HDFS_HOME,HADOOP_CONF_DIR,YARN_HOME,AWS_CONTAINER_CREDENTIALS_RELATIVE_URI,AWS_REGION</value>
          <description>Environment variable whitelist</description>
      </property>
 

--- a/spark/processing/3.1/py3/hadoop-config/yarn-site.xml
+++ b/spark/processing/3.1/py3/hadoop-config/yarn-site.xml
@@ -27,7 +27,7 @@
      </property>
      <property>
          <name>yarn.nodemanager.env-whitelist</name>
-         <value>JAVA_HOME,HADOOP_COMMON_HOME,HADOOP_HDFS_HOME,HADOOP_CONF_DIR,YARN_HOME,AWS_CONTAINER_CREDENTIALS_RELATIVE_URI</value>
+         <value>JAVA_HOME,HADOOP_COMMON_HOME,HADOOP_HDFS_HOME,HADOOP_CONF_DIR,YARN_HOME,AWS_CONTAINER_CREDENTIALS_RELATIVE_URI,AWS_REGION</value>
          <description>Environment variable whitelist</description>
      </property>
 

--- a/src/smspark/bootstrapper.py
+++ b/src/smspark/bootstrapper.py
@@ -428,7 +428,7 @@ class Bootstrapper:
                 "spark.executor.instances": f"{executor_count_total}",
                 "spark.default.parallelism": f"{default_parallelism}",
                 "spark.yarn.appMasterEnv.AWS_REGION": f"{aws_region}",
-                "spark.executorEnv.AWS_REGION": f"{aws_region}"
+                "spark.executorEnv.AWS_REGION": f"{aws_region}",
             },
         )
 


### PR DESCRIPTION
*Issue #, if available:*
Fix the issue that AWS_REGION is still not available in worker node when using multi-instances.

*Description of changes:*
Whitelist AWS_REGION in yarn-site.xml, rerun the test and verified processing job with multiple instances can run successfully. And also fixed the python format check failure

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
