### PR TITLE
Processingjobconfig error message

### DIFF
--- a/src/smspark/job.py
+++ b/src/smspark/job.py
@@ -62,7 +62,7 @@ class ProcessingJobManager(object):
                 self._processing_job_config = json.load(f)
         except Exception:
             self.logger.warning(
-                "Could not read resource config file at {}. Using default resourceconfig.".format(resource_config_path)
+                "Could not read processing job config file at {}. Using default processingjobconfig.".format(processing_job_config_path)
             )
             self._processing_job_config = default_processing_job_config
 

--- a/test/unit/test_bootstrapper.py
+++ b/test/unit/test_bootstrapper.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import json
+import os
 from unittest.mock import MagicMock, Mock, PropertyMock, call, mock_open, patch
 
 import pytest
@@ -371,6 +372,7 @@ def test_set_yarn_spark_resource_config_fallback(
     patched_spark_config.write_config.assert_called_once()
 
 
+@patch.dict(os.environ, {"AWS_REGION": "us-west-2"})
 def test_get_yarn_spark_resource_config(default_bootstrapper: Bootstrapper) -> None:
     # Using a cluster with one single m5.xlarge instance, calculate Yarn and Spark configs, and double check the math
     instance_mem_mb = 16384
@@ -431,6 +433,8 @@ def test_get_yarn_spark_resource_config(default_bootstrapper: Bootstrapper) -> N
         "spark.executor.defaultJavaOptions": f"{exp_executor_java_opts}",
         "spark.executor.instances": f"{exp_executor_count_total}",
         "spark.default.parallelism": f"{exp_default_parallelism}",
+        "spark.executorEnv.AWS_REGION": "us-west-2",
+        "spark.yarn.appMasterEnv.AWS_REGION": "us-west-2",
     }
 
     assert spark_config.Classification == "spark-defaults"


### PR DESCRIPTION
*Issue #, if available:*

The error message when processing job config is missing is incorrect and misleading. The message is copy from the case when resource config is missing.

*Description of changes:*

Fix the error massage so it contains reference to processing job config

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
