### PR TITLE
Ignore numpy and urllib3 safety checks.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ build-container-library: init
 	cp -- dist/*.whl ${BUILD_CONTEXT}
 
 install-container-library: init
-	pipenv run safety check  # https://github.com/pyupio/safety
+	pipenv run safety check -i 44717 -i 44716 -i 44715 -i 43975  # https://github.com/pyupio/safety
 
 build-static-config:
 	./scripts/fetch-ec2-instance-type-info.sh --region ${REGION} --use-case ${USE_CASE} --spark-version ${SPARK_VERSION} \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

These safety checks are failing in CI, but I found it impossible to fix them on the Pipfile, also becase numpy 1.22 was not available to install with Pip.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
