### PR TITLE
clean up python 3.9 installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,19 +30,20 @@ all: build test
 
 # Downloads EMR packages. Skips if the tar file containing EMR packages has been made.
 
-init:
-	pip install pipenv --upgrade
+init: build-container-library
+	python3 -m pip install pipenv==2022.4.8
 	cp smsparkbuild/${FRAMEWORK_VERSION}/Pipfile .
 	cp smsparkbuild/${FRAMEWORK_VERSION}/pyproject.toml .
-	cp smsparkbuild/${FRAMEWORK_VERSION}/setup.py .
 	pipenv install
+# 	pipenv run pip install dist/*.whl
 	cp Pipfile ${BUILD_CONTEXT}
 	cp Pipfile.lock ${BUILD_CONTEXT}
 	cp setup.py ${BUILD_CONTEXT}
 
 # Builds and moves container python library into the Docker build context
-build-container-library: init
-	python setup.py bdist_wheel;
+build-container-library: 
+	cp smsparkbuild/${FRAMEWORK_VERSION}/setup.py .
+	python3 setup.py bdist_wheel;
 	cp -- dist/*.whl ${BUILD_CONTEXT}
 
 install-container-library: init

--- a/spark/processing/3.1/py3/docker/py39/Dockerfile.cpu
+++ b/spark/processing/3.1/py3/docker/py39/Dockerfile.cpu
@@ -3,20 +3,25 @@ ARG REGION
 ENV AWS_REGION ${REGION}
 RUN yum clean all
 RUN yum update -y
-RUN yum install -y awscli bigtop-utils curl gcc gzip unzip python3-setuptools python3-pip python-devel python3-devel python-psutil gunzip tar wget liblapack* libblas* libopencv* libopenblas*
+RUN yum install -y awscli bigtop-utils curl gcc gzip zip unzip gunzip tar wget liblapack* libblas* libopencv* libopenblas* python3-setuptools python3-pip python-devel python3-devel python-psutil
+
 
 # Install python 3.9
-RUN yum -y install gcc openssl-devel bzip2-devel libffi-devel
-RUN yum -y install tar xz wget gzip make
-RUN wget https://www.python.org/ftp/python/3.9.9/Python-3.9.9.tgz
-RUN tar xzf Python-3.9.9.tgz
+ARG PYTHON_VERSION="3.9.12"
+RUN yum -y install openssl-devel bzip2-devel libffi-devel xz make
+RUN wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz
+RUN tar xzf Python-${PYTHON_VERSION}.tgz
 RUN cd Python-*/ && ./configure --enable-optimizations && make altinstall
 RUN echo 'alias python3=python3.9' >> ~/.bashrc
 
+# clean up python
+RUN rm Python-${PYTHON_VERSION}.tgz
+RUN rm -rf Python-${PYTHON_VERSION}
+RUN yum remove -y make xz bzip2-devel
+
 # install nginx amazonlinux:2.0.20200304.0 does not have nginx, so need to install epel-release first
 RUN wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-RUN yum install -y epel-release-latest-7.noarch.rpm
-RUN yum install -y nginx
+RUN yum install -y epel-release-latest-7.noarch.rpm nginx
 
 RUN rm -rf /var/cache/yum
 
@@ -68,7 +73,6 @@ RUN yum install -y aws-hm-client \
     hive-hcatalog-server \
     hive-jdbc \
     hive-server2 \
-    python37-numpy \
     s3-dist-cp \
     spark-core \
     spark-datanucleus \
@@ -91,21 +95,17 @@ ENV HDFS_SECONDARYNAMENODE_USER="root"
 RUN zip -q -d /lib/hive/lib/log4j-core-2.10.0.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
 
 # Set up bootstrapping program and Spark configuration
-RUN pwd
-RUN ls
 COPY *.whl /opt/program/
-RUN /usr/local/bin/python3.9 -m pip install pipenv --upgrade
 COPY hadoop-config /opt/hadoop-config
 COPY nginx-config /opt/nginx-config
 COPY aws-config /opt/aws-config
-COPY Pipfile /opt/program/
-COPY Pipfile.lock /opt/program/
-COPY setup.py /opt/program/
+COPY Pipfile Pipfile.lock setup.py *.whl /opt/program/
 ENV PIPENV_PIPFILE=/opt/program/Pipfile
 # Use --system flag, so it will install all packages into the system python,
 # and not into the virtualenv. Since docker containers do not need to have virtualenvs
-RUN pipenv install --system
-RUN /usr/local/bin/python3.9 -m pip install /opt/program/*.whl
+RUN /usr/local/bin/python3.9 -m pip install pipenv==2022.4.8 \
+    && pipenv install --system \
+    && /usr/local/bin/python3.9 -m pip install /opt/program/*.whl
 
 # Setup container bootstrapper
 COPY container-bootstrap-config /opt/container-bootstrap-config


### PR DESCRIPTION
*Issue #, if available:*
After install python 3.9, image size increased 400MB. Clean up container after installing python 3.9


*Description of changes:*
1. Instead of installing smspark in Pipfile, install it using pip
2. Change the dependency between init and build-container-library
3. Remove python3.7 related dependencies

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
