### PR TITLE
fix 3.1 py39 Dockerfile issue

### DIFF
--- a/new_images.yml
+++ b/new_images.yml
@@ -4,4 +4,4 @@ new_images:
     use-case: "processing"
     processors: ["cpu"]
     python: ["py39"]
-    sm_version: "1.1"
+    sm_version: "1.2"

--- a/spark/processing/3.1/py3/docker/py39/Dockerfile.cpu
+++ b/spark/processing/3.1/py3/docker/py39/Dockerfile.cpu
@@ -18,7 +18,7 @@ RUN yum -y groupinstall 'Development Tools' \
     && cd Python-*/ \
     && ./configure --enable-optimizations \
     && make altinstall \
-    && echo 'alias python3=python3.9\nalias pip3=pip3.9' >> ~/.bashrc \
+    && echo -e 'alias python3=python3.9\nalias pip3=pip3.9' >> ~/.bashrc \
     && ln -s $(which ${PYTHON_WITH_BASE_VERSION}) /usr/local/bin/python3 \
     && ln -s $(which ${PIP_WITH_BASE_VERSION}) /usr/local/bin/pip3 \
     && cd .. \


### PR DESCRIPTION
*Issue #, if available:*
In 3.1 py39 Dockerfile, we miss `-e` when echo python3 alias to bashrc file. 

*Description of changes:*
Update minor version and add `-e` in echo command

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
