### PR TITLE
Remove py as dependency which cause security vulnerability check fail

### DIFF
--- a/smsparkbuild/py39/Pipfile
+++ b/smsparkbuild/py39/Pipfile
@@ -35,7 +35,6 @@ importlib-metadata = "==4.11.3"
 pytest-parallel = "==0.1.1"
 pytest-rerunfailures = "10.0"
 numpy = "==1.22.2"
-py = "==1.11.0"
 
 [requires]
 python_version = "3.9"


### PR DESCRIPTION
*Issue #, if available:*
Remove py as dependency which cause security vulnerability check fail

*Description of changes:*
```
REPORT

  Safety is using PyUp's free open-source vulnerability database. This data is 30 days old and limited.
  For real-time enhanced vulnerability data, fix recommendations, severity reporting, cybersecurity support, team and project
policy management and more sign up at https://pyup.io or email sales@pyup.io

  Safety v2.3.5 is scanning for Vulnerabilities...
  Scanning dependencies in your environment:

  -> /Users/sucan/.local/share/virtualenvs/sagemaker-spark-container-xdAyGb4R/lib/python3.9/site-packages

  Using non-commercial database
  Found and scanned 98 packages
  Timestamp 2023-03-23 16:32:45
  0 vulnerabilities found
  0 vulnerabilities ignored
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
