### PR TITLE
resolve netty version conflict

### DIFF
--- a/spark/processing/3.2/py3/docker/py39/Dockerfile.cpu
+++ b/spark/processing/3.2/py3/docker/py39/Dockerfile.cpu
@@ -127,6 +127,7 @@ WORKDIR $SPARK_HOME
 
 # Install the sagemaker feature store spark connector
 # https://docs.aws.amazon.com/sagemaker/latest/dg/batch-ingestion-spark-connector-setup.html
-RUN /usr/local/bin/python3.9 -m pip install sagemaker-feature-store-pyspark-3.2 --no-binary :all:
+# Temp fix for 3.3 to solve netty version conflict
+# RUN /usr/local/bin/python3.9 -m pip install sagemaker-feature-store-pyspark-3.2 --no-binary :all:
 
 ENTRYPOINT ["smspark-submit"]

--- a/spark/processing/3.3/py3/docker/py39/Dockerfile.cpu
+++ b/spark/processing/3.3/py3/docker/py39/Dockerfile.cpu
@@ -127,6 +127,7 @@ WORKDIR $SPARK_HOME
 
 # Install the sagemaker feature store spark connector
 # https://docs.aws.amazon.com/sagemaker/latest/dg/batch-ingestion-spark-connector-setup.html
-RUN /usr/local/bin/python3.9 -m pip install sagemaker-feature-store-pyspark-3.2 --no-binary :all:
+# Temp fix for 3.3 to solve netty version conflict
+# RUN /usr/local/bin/python3.9 -m pip install sagemaker-feature-store-pyspark-3.2 --no-binary :all:
 
 ENTRYPOINT ["smspark-submit"]


### PR DESCRIPTION
* resolve netty version by remove the feature store connector from docker file

*Issue #, if available:*
For Spark 3.2, the community version of spark bumped up the netty-all version to 4.1.68, reference is [here](https://mvnrepository.com/artifact/org.apache.spark/spark-core_2.13/3.2.1). And 4.1.68 of netty still has all transitive dependencies as optional, just like 4.1.51. However, for unknown reason, both EMR and sagemaker processing container are pulling 4.1.74 which breaks the original dependency tree (transitive dependencies are no longer optional). EMR is using a enterprise optimized version spark. 

For Spark 3.3, spark bumped up the dependency version of netty-all to 4.1.74 which is the version starts causing the problem. Reference is [here](https://mvnrepository.com/artifact/io.netty/netty-all/4.1.74.Final).

*Description of changes:*
Remove feature store connector dependencies, feature store team will publish the fix to re-enable the library

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
