### PR TITLE
Fix integtest: Add OSU key to partition map

### DIFF
--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -58,6 +58,7 @@ def partition(region) -> str:
     """Return partition, such as aws, aws-cn, for use in tests."""
     region_partition_amp = {
         "us-gov-west-1": "aws-us-gov",
+        "us-gov-east-1": "aws-us-gov",
         "cn-north-1": "aws-cn",
         "cn-northwest-1": "aws-cn",
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix integtest: Add OSU key to partition map

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
